### PR TITLE
nStoreSession.get() bug fixed.

### DIFF
--- a/lib/nstore-session.js
+++ b/lib/nstore-session.js
@@ -8,9 +8,16 @@
  * Module dependencies.
  * Assumes "connect" and "nstore" are in the library path
  */
+
 var sys = require('sys'),
-    Store = require('connect/middleware/session/store'),
-    nStore = require('nStore');
+    nStore = require('nStore'),
+    connectVersion = require('connect').version;
+
+if(connectVersion.substring(0,1)=='0'){
+   var Store = require('connect/middleware/session/store');
+}else{
+   var Store = require('connect/lib/middleware/session/store');
+}
 
 /**
  * Initialize nStoreSession with the given `options`.
@@ -38,7 +45,13 @@ sys.inherits(nStoreSession, Store);
  * @api public
  */
 nStoreSession.prototype.get = function (hash, fn) {
-  this.db.get(hash, fn);
+  this.db.get(hash, function(err,data,meta){
+     if(err instanceof Error){
+        fn();
+     }else{
+        fn(null,data,meta);
+     }
+  });
 };
 
 /**


### PR DESCRIPTION
nStore.getKey() return an error object as response when nothing found in database. Using connect-nstoresession caused killing the whole process in these situations. So I changed nSotreSession.get() to return null when such error occur. 

Also now, it is ready for connect >= v1.0.0
